### PR TITLE
Prevent submitting the form on hitting enter

### DIFF
--- a/resources/js/components/GoogleAutocomplete/FormField.vue
+++ b/resources/js/components/GoogleAutocomplete/FormField.vue
@@ -10,6 +10,7 @@
                         :placeholder="placeholder"
                         :country="field.countries"
                         v-model="value"
+                        v-on:keypress.enter.prevent=""
                         v-on:placechanged="getAddressData">
                 </vue-google-autocomplete>
             </div>


### PR DESCRIPTION
If you select a result with your keyboard and hit enter, then you form is submitted. This code prevents this behaviour.