### PR TITLE
Correct the return type in doc block

### DIFF
--- a/src/AddressMetadata.php
+++ b/src/AddressMetadata.php
@@ -35,7 +35,7 @@ class AddressMetadata extends Text
      * The value for autocomplete
      *
      * @param string $addressValue
-     * @return void
+     * @return $this
      */
     public function fromValue(string $addressValue)
     {
@@ -45,7 +45,7 @@ class AddressMetadata extends Text
     /**
      * Set the field in disabled mode
      *
-     * @return void
+     * @return $this
      */
     public function disabled()
     {  
@@ -55,7 +55,7 @@ class AddressMetadata extends Text
     /**
      * Set the field invisible but save it
      *
-     * @return void
+     * @return $this
      */
     public function invisible()
     {  

--- a/src/GoogleAutocomplete.php
+++ b/src/GoogleAutocomplete.php
@@ -37,7 +37,7 @@ class GoogleAutocomplete extends Field
      * Pass a country codes array
      *
      * @param [type] $list
-     * @return void
+     * @return $this
      */
     public function countries($list){
         return $this->withMeta([
@@ -51,7 +51,7 @@ class GoogleAutocomplete extends Field
      * https://developers.google.com/places/supported_types#table3
      *
      * @param string $type
-     * @return void
+     * @return $this
      */
     public function placeType($type){
         return $this->withMeta([


### PR DESCRIPTION
This avoids code editors from throwing warning about the methods returning void and allows for autocomplete of methods.