### PR TITLE
Updated address meta formfield to use v-show

### DIFF
--- a/resources/js/components/AddressMetadata/FormField.vue
+++ b/resources/js/components/AddressMetadata/FormField.vue
@@ -1,21 +1,19 @@
 <template>
-    <component :is="field.invisible ? 'div' : 'template'" :class="{ invisible: field.invisible }">
-        <default-field :field="field">
-            <template slot="field">
-                <input :id="field.name" type="text"
-                    :disabled="field.disabled"
-                    class="w-full form-control form-input form-input-bordered"
-                    :class="errorClasses"
-                    :placeholder="field.name"
-                    v-model="value"
-                />
+    <default-field :field="field" v-show="field.invisible !== true">
+        <template slot="field">
+            <input :id="field.name" type="text"
+                :disabled="field.disabled"
+                class="w-full form-control form-input form-input-bordered"
+                :class="errorClasses"
+                :placeholder="field.name"
+                v-model="value"
+            />
 
-                <p v-if="hasError" class="help-text error-text mt-2 text-danger">
-                    {{ firstError }}
-                </p>
-            </template>
-        </default-field>
-    </component>
+            <p v-if="hasError" class="help-text error-text mt-2 text-danger">
+                {{ firstError }}
+            </p>
+        </template>
+    </default-field>
 </template>
 
 <script>

--- a/resources/js/components/AddressMetadata/FormField.vue
+++ b/resources/js/components/AddressMetadata/FormField.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="{ invisible: field.invisible }">
+    <component :is="field.invisible ? 'div' : 'template'" :class="{ invisible: field.invisible }">
         <default-field :field="field">
             <template slot="field">
                 <input :id="field.name" type="text"
@@ -15,7 +15,7 @@
                 </p>
             </template>
         </default-field>
-    </div>
+    </component>
 </template>
 
 <script>

--- a/resources/js/components/AddressMetadata/FormField.vue
+++ b/resources/js/components/AddressMetadata/FormField.vue
@@ -88,10 +88,3 @@ export default {
     }
 }
 </script>
-
-<style>
-    .invisible {
-        visibility: hidden;
-        position: absolute;
-    }
-</style>


### PR DESCRIPTION
Currently there is a visual bug because of the parent div in front of <default-field>.
If the field is not invisible we could just use the v-show attribute.